### PR TITLE
Make sure the task fails whenever an error is found in any file

### DIFF
--- a/tasks/puglint.js
+++ b/tasks/puglint.js
@@ -37,14 +37,16 @@ module.exports = function(grunt) {
     }
 
     var errors = [];
+    var failed = false;
     this.filesSrc.forEach(function(filepath) {
       errors = linter.checkFile(filepath);
 
       if (errors.length) {
+        failed = true;
         formatter.formatOutput(errors);
       }
     });
 
-    done(errors.length === 0);
+    done(!failed);
   });
 };


### PR DESCRIPTION
Task currently fails or succeeds based only on the last file checked for errors. This is a suggestion to fix the logic to make sure it fails whenever an error is found in any of the files.
