### PR TITLE
Fix failure when item.msg is array

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -31,6 +31,16 @@ module.exports = function (grunt) {
         src: ['test/fixtures/**/*.jade']
       },
 
+      // Array messages
+      arrayMessages: {
+        options: {
+          preset: {
+            disallowSpacesInsideAttributeBrackets: true
+          }
+        },
+        src: ['test/fixtures/**/*.jade']
+      },
+
       // RC file
       rcFile: {
         options: {

--- a/lib/formatter.js
+++ b/lib/formatter.js
@@ -12,7 +12,7 @@ var cwd = process.cwd();
  */
 var formatRow = function(item) {
   // Drop newline symbol in error string
-  item.msg = item.msg.replace('\n', '');
+  item.msg = (Array.isArray(item.msg) ? item.msg.join(' ') : item.msg).replace('\n', '');
   // Using zero instead of undefined
   item.column = (item.column === undefined) ? 0 : item.column;
   // Drop `PUG:LINT_` prefix in error code

--- a/test/fixtures/invalid.jade
+++ b/test/fixtures/invalid.jade
@@ -21,3 +21,5 @@ html(lang='en')
         templating language with a
         strong focus on performance
         and powerful features.
+
+      span( role='such spaces produce pug-lint messages as an array' )

--- a/test/test.js
+++ b/test/test.js
@@ -31,6 +31,16 @@ test.cb('Custom config with the object in the options', function(t) {
   });
 });
 
+test.cb('Array messages', function(t) {
+  exec('grunt puglint:arrayMessages', function(err, stdout) {
+    var isOneError = /Illegal space after opening bracket\s+DISALLOWSPACESINSIDEATTRIBUTEBRACKETS/.test(stdout.toString());
+    var isTwoError = /Illegal space before closing bracket\s+DISALLOWSPACESINSIDEATTRIBUTEBRACKETS/.test(stdout.toString());
+
+    t.same(isOneError && isTwoError, true);
+    t.end();
+  });
+});
+
 test.cb('RC file', function(t) {
   exec('grunt puglint:rcFile', function(err, stdout) {
     var isOneError = /REQUIRECLASSLITERALSBEFOREIDLITERALS/.test(stdout.toString());


### PR DESCRIPTION
Sometimes item.msg is array.
**Example**: `[ 'Illegal space', 'before', 'closing bracket' ]`
